### PR TITLE
Node can be a PdfString or a reference to a PdfString

### DIFF
--- a/pdf/src/primitive.rs
+++ b/pdf/src/primitive.rs
@@ -205,6 +205,7 @@ impl Object for PdfString {
     fn from_primitive(p: Primitive, _: &impl Resolve) -> Result<Self> {
         match p {
             Primitive::String (string) => Ok(string),
+            Primitive::Reference(id) => Ok(r.resolve(id)?.to_string()?),
             _ => unexpected_primitive!(String, p.get_debug_name()),
         }
     }


### PR DESCRIPTION
Title type has changed from PdfString to Ref<PdfString>